### PR TITLE
Sort null values properly

### DIFF
--- a/lib/sort-array.js
+++ b/lib/sort-array.js
@@ -104,9 +104,9 @@ function sortByFunc (properties, customOrder) {
     var x = objectGet(a, property)
     var y = objectGet(b, property)
 
-    if (!t.isDefined(x) && t.isDefined(y)) {
+    if ((!t.isDefined(x) || x === null) && t.isDefined(y)) {
       result = -1
-    } else if (t.isDefined(x) && !t.isDefined(y)) {
+    } else if (t.isDefined(x) && (!t.isDefined(y) || y === null)) {
       result = 1
     } else if (!t.isDefined(x) && !t.isDefined(y)) {
       result = 0

--- a/lib/sort-array.js
+++ b/lib/sort-array.js
@@ -104,7 +104,9 @@ function sortByFunc (properties, customOrder) {
     var x = objectGet(a, property)
     var y = objectGet(b, property)
 
-    if ((!t.isDefined(x) || x === null) && t.isDefined(y)) {
+    if (x === null && y === null) {
+      result = 0
+    } else if ((!t.isDefined(x) || x === null) && t.isDefined(y)) {
       result = -1
     } else if (t.isDefined(x) && (!t.isDefined(y) || y === null)) {
       result = 1

--- a/test/test.js
+++ b/test/test.js
@@ -139,7 +139,7 @@ test('sort by deep value, custom order', function (t) {
   t.end()
 })
 
-runner.test('sort nulls', function () {
+test('sort nulls', function (t) {
   const expected = [
     { importance: 'speed', weight: null },
     { importance: 'strength', weight: null },
@@ -163,10 +163,11 @@ runner.test('sort nulls', function () {
     { importance: 'strength', weight: 'medium' }
   ]
   const result = sortBy(fixture, 'weight')
-  a.deepStrictEqual(result, expected)
+  t.deepEqual(result, expected)
+  t.end()
 })
 
-runner.test('sortBy with nulls', function () {
+test('sortBy with nulls', function (t) {
   const fixture = [
     { a: 4, b: null, c: 3 },
     { a: 4, b: 2, c: null },
@@ -190,5 +191,6 @@ runner.test('sortBy with nulls', function () {
     { a: 4, b: 3, c: null }
   ]
   const result = sortBy(fixture, ['a', 'b', 'c'])
-  a.deepStrictEqual(result, expected)
+  t.deepEqual(result, expected)
+  t.end()
 })

--- a/test/test.js
+++ b/test/test.js
@@ -138,3 +138,57 @@ test('sort by deep value, custom order', function (t) {
   t.deepEqual(result, expected)
   t.end()
 })
+
+runner.test('sort nulls', function () {
+  const expected = [
+    { importance: 'speed', weight: null },
+    { importance: 'strength', weight: null },
+    { importance: 'intelligence', weight: null },
+    { importance: 'strength', weight: 'high' },
+    { importance: 'speed', weight: 'high' },
+    { importance: 'intelligence', weight: 'high' },
+    { importance: 'intelligence', weight: 'medium' },
+    { importance: 'speed', weight: 'medium' },
+    { importance: 'strength', weight: 'medium' }
+  ]
+  const fixture = [
+    { importance: 'intelligence', weight: 'medium' },
+    { importance: 'strength', weight: 'high' },
+    { importance: 'speed', weight: null },
+    { importance: 'strength', weight: null },
+    { importance: 'speed', weight: 'high' },
+    { importance: 'intelligence', weight: null },
+    { importance: 'speed', weight: 'medium' },
+    { importance: 'intelligence', weight: 'high' },
+    { importance: 'strength', weight: 'medium' }
+  ]
+  const result = sortBy(fixture, 'weight')
+  a.deepStrictEqual(result, expected)
+})
+
+runner.test('sortBy with nulls', function () {
+  const fixture = [
+    { a: 4, b: null, c: 3 },
+    { a: 4, b: 2, c: null },
+    { a: 2, b: 2, c: 3 },
+    { a: 2, b: 2, c: 2 },
+    { a: null, b: 3, c: 4 },
+    { a: null, b: null, c: 4 },
+    { a: null, b: 2, c: 4 },
+    { a: 3, b: 3, c: 3 },
+    { a: 4, b: 3, c: null }
+  ]
+  const expected = [
+    { a: null, b: null, c: 4 },
+    { a: null, b: 2, c: 4 },
+    { a: null, b: 3, c: 4 },
+    { a: 2, b: 2, c: 2 },
+    { a: 2, b: 2, c: 3 },
+    { a: 3, b: 3, c: 3 },
+    { a: 4, b: null, c: 3 },
+    { a: 4, b: 2, c: null },
+    { a: 4, b: 3, c: null }
+  ]
+  const result = sortBy(fixture, ['a', 'b', 'c'])
+  a.deepStrictEqual(result, expected)
+})

--- a/test/test.js
+++ b/test/test.js
@@ -139,7 +139,7 @@ test('sort by deep value, custom order', function (t) {
   t.end()
 })
 
-test('sort nulls', function (t) {
+runner.test('sort nulls', function () {
   const expected = [
     { importance: 'speed', weight: null },
     { importance: 'strength', weight: null },
@@ -163,11 +163,10 @@ test('sort nulls', function (t) {
     { importance: 'strength', weight: 'medium' }
   ]
   const result = sortBy(fixture, 'weight')
-  t.deepEqual(result, expected)
-  t.end()
+  a.deepStrictEqual(result, expected)
 })
 
-test('sortBy with nulls', function (t) {
+runner.test('sortBy with nulls', function () {
   const fixture = [
     { a: 4, b: null, c: 3 },
     { a: 4, b: 2, c: null },
@@ -191,6 +190,5 @@ test('sortBy with nulls', function (t) {
     { a: 4, b: 3, c: null }
   ]
   const result = sortBy(fixture, ['a', 'b', 'c'])
-  t.deepEqual(result, expected)
-  t.end()
+  a.deepStrictEqual(result, expected)
 })


### PR DESCRIPTION
Null values are currently being sorted into random positions within the sorted results, adding null checks puts them in the expected positions.